### PR TITLE
limpiarcampos

### DIFF
--- a/cucaibafront/src/components/HonorariosPorAgentes.jsx
+++ b/cucaibafront/src/components/HonorariosPorAgentes.jsx
@@ -406,6 +406,7 @@ const HonorariosPorAgente = () => {
                     setSelectValue(null);
                     setShowDropdown(false);
                     setOperativoData({});
+                    setSelectedOptions([]);
                   }}
                 >
                   <FaRedo />


### PR DESCRIPTION
Corrigiendo el boton limpiar campos; no desalmacenaba los módulos.